### PR TITLE
Reset URL load flag to refresh music section

### DIFF
--- a/main.js
+++ b/main.js
@@ -145,6 +145,10 @@ function loadFromURL() {
         // Update URL to reflect final state
         const currentTrackId = window.globalPlayer?.getCurrentTrackId?.() || null;
         updateURL(targetPage, currentTrackId);
+
+        // Allow subsequent automatic updates and refresh music section
+        isLoadingFromURL = false;
+        window.globalPlayer?.updateMusicSection?.();
     }, 600); // Wait for page load + a bit more
 }
 


### PR DESCRIPTION
## Summary
- reset `isLoadingFromURL` after initial load
- refresh music section once deep link finishes loading

## Testing
- `node --check main.js && echo "main.js syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_689fa610f0848333b67c2137e60ea6a9